### PR TITLE
Correct probable mistake: Amazon's Dynamo does not offer single-copy consistency

### DIFF
--- a/input/5_eventual.md
+++ b/input/5_eventual.md
@@ -29,7 +29,7 @@ Within the set of systems providing eventual consistency, there are two types of
 
 *Eventual consistency with probabilistic guarantees*. This type of system can detect conflicting writes at some later point, but does not guarantee that the results are equivalent to some correct sequential execution. In other words, conflicting updates will sometimes result in overwriting a newer value with an older one and some anomalies can be expected to occur during normal operation (or during partitions).
 
-In recent years, the most influential system design offering single-copy consistency is Amazon's Dynamo, which I will discuss as an example of a system that offers eventual consistency with probabilistic guarantees.
+In recent years, the most influential system design is Amazon's Dynamo, which I will discuss as an example of a system that offers eventual consistency with probabilistic guarantees.
 
 *Eventual consistency with strong guarantees*. This type of system guarantees that the results converge to a common value equivalent to some correct sequential execution. In other words, such systems do not produce any anomalous results; without any coordination you can build replicas of the same service, and those replicas can communicate in any pattern and receive the updates in any order, and they will eventually agree on the end result as long as they all see the same information.
 


### PR DESCRIPTION
You stated: "In recent years, the most influential system design offering single-copy consistency is Amazon's Dynamo,[...]"

A few paragraphs later you say "Dynamo prioritizes availability over consistency; it does not guarantee single-copy consistency."

I suppose that Dynamo does not guarantee single-copy consistency using default settings. I'm not completely sure if it is possible to tweak Dynamo to offer single-copy consistency. Nonetheless, the first sentece confused me. 
Do you agree?
