### PR TITLE
Use fs.writeFileSync to replace fs.writeFile

### DIFF
--- a/bookgen/generate.js
+++ b/bookgen/generate.js
@@ -54,7 +54,7 @@ BookGen.processFiles = function(config, files) {
   }).join('<div style="page-break-after: always;"></div>');
 
   // write a single page version as well
-  fs.writeFile(config.output+'single-page.html',
+  fs.writeFileSync(config.output+'single-page.html',
     header.replace('assets/style.css', 'assets/printable.css')
       .replace(/{{prev}}/g, 'index.html')
       .replace(/{{next}}/g, 'index.html')
@@ -71,7 +71,7 @@ BookGen.processFiles = function(config, files) {
         .replace(/{{prev}}/g, 'index.html')
         .replace(/{{next}}/g, 'index.html')
     );
-  fs.writeFile(config.output+'ebook.html',
+  fs.writeFileSync(config.output+'ebook.html',
     header.replace(/<link[^>]+>/g, '')
           .replace(/{{prev}}/g, 'index.html')
           .replace(/{{next}}/g, 'index.html')


### PR DESCRIPTION
If run `make build` in node version newer than 7.0.0 (https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback) will emit a deprecation warning like that
```
(node:57745) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

Use fs.writeFileSync to replace fs.writeFile