### PR TITLE
Fix typo on image interpretation line

### DIFF
--- a/input/5_eventual.md
+++ b/input/5_eventual.md
@@ -233,7 +233,7 @@ Based on the paper, during normal operation eventually consistent data stores ar
 
 ![from the PBS paper](./images/pbs.png)
 
-For example, going from `R=1`, `W=1` to `R=2`, `W=1` in the Yammer case reduces the inconsistency window from 1352 ms to 202 ms - while keeping the read latencies lower (32.6 ms) than the fastest strict quorum (`R=3`, `W=1`; 219.27 ms).
+For example, going from `R=1`, `W=1` to `R=2`, `W=1` in the Yammer case reduces the inconsistency window from 1364 ms to 202 ms - while keeping the read latencies lower (32.6 ms) than the fastest strict quorum (`R=3`, `W=1`; 219.27 ms).
 
 For more details, have a look at the [PBS website](http://pbs.cs.berkeley.edu/)  and the associated paper.
 


### PR DESCRIPTION
According to the image in the book, I believe this is the correct interpretation:

<img width="679" alt="screen shot 2019-01-27 at 4 28 30 pm" src="https://user-images.githubusercontent.com/5652128/51809063-50837a80-2251-11e9-8a8e-67add0aa057c.png">