### PR TITLE
Fix bug in VectorClock example

### DIFF
--- a/input/3_time.md
+++ b/input/3_time.md
@@ -225,7 +225,7 @@ Again, expressed as code:
           b = other.value;
       // This filters out duplicate keys in the hash
       (Object.keys(a)
-        .concat(b))
+        .concat(Object.keys(b)))
         .sort()
         .filter(function(key) {
           var isDuplicate = (key == last);


### PR DESCRIPTION
Great book, thanks for writing it!

I think there's a bug in the merge method in the VectorClock example; as-is the result of the concatenation will be something like:
```
['foo', 'bar', { 'foo': 1, 'bar': 2 }]
```
And I believe it should be more like:
```
['foo', 'bar', 'foo', 'bar']
```